### PR TITLE
Added Pre-Commit Hygiene Hooks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,595 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        too-many-arguments
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/dai_cadcad/policies.py
+++ b/dai_cadcad/policies.py
@@ -1,3 +1,17 @@
+""" Policies Module
+
+Contains the definition of the cadCAD system's policies.
+Policies are typically broken down into `{{policy_name}}_all()` and `{{policy_name}}()` functions,
+where the `_all()` is the actual "policy" function passed into the PSUBs, and the other is a helper
+function.
+
+The helper function typically contains the actual policy logic,
+from the perspective of a single actor/action (executing the policy once).
+
+The `_all()` typically orchestrates how many times the policy should execute, and with what options,
+as well as checking the necessary conditions.
+"""
+
 from uuid import uuid4
 from copy import deepcopy
 
@@ -6,45 +20,53 @@ from copy import deepcopy
 
 # TODO
 # Be sure to remember the ETH_LINE assertion, and to add `eth` to `state.eth_ilk`'s `debt_dai`.
-def join_all(_params, substep, sH, s, **kwargs):
-    '''Generates and executes all `join` operations.
-       Currently, this only occurs in a 1-step warmup period.'''
-    if (_params["WARM_TAU"] >= s["timestep"]):
-      new_vat = deepcopy(s["vat"])
-      new_eth_ilk = deepcopy(s["eth_ilk"])
-      for i in range(1000):
-        join(150, 100, new_vat, new_eth_ilk)
-      return {"vat": new_vat}
+def join_all(params, _substep, _state_hist, state):
+    """ Generates and executes all `join` operations.
+
+        Currently, this only occurs in a 1-step warmup period.
+    """
+
+    if params["WARM_TAU"] >= state["timestep"]:
+        new_vat = deepcopy(state["vat"])
+        new_eth_ilk = deepcopy(state["eth_ilk"])
+        for _ in range(1000):
+            join(150, 100, new_vat, new_eth_ilk)
+        return {"vat": new_vat}
+    return {}
 
 
 def join(eth, dai, new_vat, new_eth_ilk):
+    """ Executes a single `join` operation.
+
+        Creates a new vault in the `vat` containing `eth` and `dai`.
+    """
 
     # Create the new vault to be joined
     vault_id = uuid4().hex
-    new_vault = {
-        "vault_id": vault_id,
-        "eth": eth,
-        "dai": dai,
-        "bitten": False
-    }
+    new_vault = {"vault_id": vault_id, "eth": eth, "dai": dai, "bitten": False}
 
     new_vat[vault_id] = new_vault
 
     new_eth_ilk["debt_dai"] += dai
+
 
 # ---
 
 
 # Cat
 
-def bite_all(_params, substep, sH, s, **kwargs):
-    '''Searches through all vaults in the vat, and returns a list
-       of `bite` policy functions for each undercollateralized one.'''
 
-    new_vat = deepcopy(s["vat"])
-    new_flipper = deepcopy(s["flipper"])
-    spot_rate = s["eth_ilk"]["spot_rate"]
-    stability_rate = s["eth_ilk"]["stability_rate"]
+def bite_all(params, _substep, _state_hist, state):
+    """ Generates and executes all `bite` operations.
+
+        Searches through all vaults in the vat, and returns a list
+        of `bite` policy functions for each undercollateralized one.
+    """
+
+    new_vat = deepcopy(state["vat"])
+    new_flipper = deepcopy(state["flipper"])
+    spot_rate = state["eth_ilk"]["spot_rate"]
+    stability_rate = state["eth_ilk"]["stability_rate"]
 
     for vault_id in new_vat:
 
@@ -54,15 +76,19 @@ def bite_all(_params, substep, sH, s, **kwargs):
         debt_to_flip = dai * stability_rate
         max_allowable_debt = spot_rate * eth
 
-        if (not vault["bitten"] and debt_to_flip > max_allowable_debt):
-            flip_tau = _params["FLIP_TAU"]
+        if not vault["bitten"] and debt_to_flip > max_allowable_debt:
+            flip_tau = params["FLIP_TAU"]
             bite(vault_id, debt_to_flip, eth, flip_tau, new_vat, new_flipper)
 
     return {"flipper": new_flipper, "vat": new_vat}
 
+
 # TODO: Should we still do assertions within the function itself?
 def bite(vault_id, debt_to_flip, eth, flip_tau, new_vat, new_flipper):
-    ''' Marks the given vault as bitten, and creates a new flip (effectively kicking it).'''
+    """ Executes a single `bite` operation.
+
+        Marks the given vault as bitten, and creates a new flip (effectively kicking it).
+    """
 
     # Create the Flipper auction to be kicked (adding it to the flipper is the same as kicking it)
     flip_id = uuid4().hex
@@ -74,41 +100,45 @@ def bite(vault_id, debt_to_flip, eth, flip_tau, new_vat, new_flipper):
         "lot_eth": eth,
         "bid_dai": 0,
         "bidder": "",
-        "expiry": flip_tau
+        "expiry": flip_tau,
     }
 
     new_flipper[flip_id] = new_flip
     new_vat[vault_id]["bitten"] = True
+
 
 # ---
 
 
 # Flipper
 
-def make_flip_tend(flip_id, bid, keeper_id):
 
-    def flip_tend(_params, substep, sH, s, **kwargs):
+def make_flip_tend(flip_id, bid, keeper_id):
+    """ Needs to be refactored to `_all()` convention.
+    """
+
+    def flip_tend(params, _substep, _state_hist, state):
 
         # TODO: Check that `flip` exists?
 
-        flip = s["flipper"][flip_id]
+        flip = state["flipper"][flip_id]
 
         # TODO: Check that `flip` has not expired?
 
         phase = flip["phase"]
-        assert (phase == "tend")
+        assert phase == "tend"
         bid_dai = flip["bid_dai"]
-        assert (bid > bid_dai * _params["FLIP_BEG"])
+        assert bid > bid_dai * params["FLIP_BEG"]
         # Not sure why we don't want to raise more, but this is from the smart contract
         # https://github.com/makerdao/dss/blob/master/src/flip.sol
         debt_to_flip = flip["debt_to_flip"]
-        assert (bid <= debt_to_flip)
+        assert bid <= debt_to_flip
 
-        new_flipper = deepcopy(s["flipper"])
+        new_flipper = deepcopy(state["flipper"])
         new_flip = new_flipper[flip_id]
         new_flip["bid_dai"] = bid
         new_flip["bidder"] = keeper_id
-        if (bid == debt_to_flip):
+        if bid == debt_to_flip:
             new_flip["phase"] = "dent"
         # TODO: Should timekeeping be handled here?
         new_flip["expiry"] -= 1
@@ -119,18 +149,20 @@ def make_flip_tend(flip_id, bid, keeper_id):
 
 
 def make_flip_dent(flip_id, lot, keeper_id):
+    """ Needs to be refactored to `_all()` convention.
+    """
 
-    def flip_dent(_params, substep, sH, s, **kwargs):
+    def flip_dent(params, _substep, _state_hist, state):
 
-        flip = s["flipper"][flip_id]
+        flip = state["flipper"][flip_id]
 
         phase = flip["phase"]
-        assert (phase == "dent")
+        assert phase == "dent"
 
         lot_eth = flip["lot_eth"]
-        assert (lot < lot_eth * _params["FLIP_BEG"])
+        assert lot < lot_eth * params["FLIP_BEG"]
 
-        new_flipper = deepcopy(s["flipper"])
+        new_flipper = deepcopy(state["flipper"])
         new_flip = new_flipper[flip_id]
         new_flip["lot_eth"] = lot
         new_flip["bidder"] = keeper_id
@@ -142,26 +174,28 @@ def make_flip_dent(flip_id, lot, keeper_id):
 
 
 def make_flip_deal(flip_id):
+    """ Needs to be refactored to `_all()` convention.
+    """
 
-    def flip_deal(_params, substep, sH, s, **kwargs):
+    def flip_deal(_params, _substep, _state_hist, state):
 
-        flip = s["flipper"][flip_id]
+        flip = state["flipper"][flip_id]
 
         expiry = flip["expiry"]
-        assert (expiry == 0)
+        assert expiry == 0
 
         # Move DAI bid from Keeper to Vow surplus
-        new_keepers = deepcopy(s["keepers"])
+        new_keepers = deepcopy(state["keepers"])
         new_keeper = new_keepers[flip["bidder"]]
         bid_dai = flip["bid_dai"]
         new_keeper["dai"] -= bid_dai
-        new_vow = deepcopy(s["vow"])
+        new_vow = deepcopy(state["vow"])
         new_vow["surplus_dai"] += bid_dai
 
         # If not enough Dai raised, put remainder of debt in Vow
 
         # Move ETH lot from Vault to Keeper
-        new_vat = deepcopy(s["vat"])
+        new_vat = deepcopy(state["vat"])
         new_vault = new_vat[flip["vault"]]
         lot_eth = flip["lot_eth"]
         new_vault["eth"] -= lot_eth
@@ -169,28 +203,37 @@ def make_flip_deal(flip_id):
         new_keeper["eth"] += lot_eth
 
         # Delete Flipper auction
-        new_flipper = deepcopy(s["flipper"])
+        new_flipper = deepcopy(state["flipper"])
         del new_flipper[flip_id]
 
-        return {"vow": new_vow, "keepers": new_keepers, "vat": new_vat, "flipper": new_flipper}
+        return {
+            "vow": new_vow,
+            "keepers": new_keepers,
+            "vat": new_vat,
+            "flipper": new_flipper,
+        }
 
     return flip_deal
+
 
 # ---
 
 
 # Flapper
 
+
 def make_flap_tend(flap_id, bid, keeper_id):
+    """ Needs to be refactored to `_all()` convention.
+    """
 
-    def flap_tend(_params, substep, sH, s, **kwargs):
+    def flap_tend(params, _substep, _state_hist, state):
 
-        flap = s["flapper"][flap_id]
+        flap = state["flapper"][flap_id]
 
         bid_mkr = flap["bid_mkr"]
-        assert (bid > bid_mkr * _params["FLAP_BEG"])
+        assert bid > bid_mkr * params["FLAP_BEG"]
 
-        new_flapper = deepcopy(s["flapper"])
+        new_flapper = deepcopy(state["flapper"])
         new_flap = new_flapper[flap_id]
         new_flap["bid_mkr"] = bid
         new_flap["bidder"] = keeper_id
@@ -202,49 +245,55 @@ def make_flap_tend(flap_id, bid, keeper_id):
 
 
 def make_flap_deal(flap_id):
+    """ Needs to be refactored to `_all()` convention.
+    """
 
-    def flap_deal(_params, substep, sH, s, **kwargs):
+    def flap_deal(_params, _substep, _state_hist, state):
 
-        flap = s["flapper"][flap_id]
+        flap = state["flapper"][flap_id]
 
         expiry = flap["expiry"]
-        assert (expiry == 0)
+        assert expiry == 0
 
         # Burn Keeper's MKR bid
         bid_mkr = flap["bid_mkr"]
-        new_keepers = deepcopy(s["keepers"])
+        new_keepers = deepcopy(state["keepers"])
         new_keeper = new_keepers[flap["bidder"]]
         new_keeper["mkr"] -= bid_mkr
 
         # Move DAI lot from Vow surplus to Keeper
-        new_vow = deepcopy(s["vow"])
+        new_vow = deepcopy(state["vow"])
         lot_dai = flap["lot_dai"]
         new_vow["surplus_dai"] -= lot_dai
         new_keeper["dai"] += lot_dai
 
         # Delete Flapper auction
-        new_flapper = deepcopy(s["flapper"])
+        new_flapper = deepcopy(state["flapper"])
         del new_flapper[flap_id]
 
         return {"keepers": new_keepers, "vow": new_vow, "flapper": new_flapper}
 
     return flap_deal
 
+
 # ---
 
 
 # Flopper
 
+
 def make_flop_dent(flop_id, lot, keeper_id):
+    """ Needs to be refactored to `_all()` convention.
+    """
 
-    def flop_dent(_params, substep, sH, s, **kwargs):
+    def flop_dent(params, _substep, _state_hist, state):
 
-        flop = s["flopper"][flop_id]
+        flop = state["flopper"][flop_id]
 
         lot_mkr = flop["lot_mkr"]
-        assert (lot < lot_mkr * _params["FLOP_BEG"])
+        assert lot < lot_mkr * params["FLOP_BEG"]
 
-        new_flopper = deepcopy(s["flopper"])
+        new_flopper = deepcopy(state["flopper"])
         new_flop = new_flopper[flop_id]
         new_flop["lot_mkr"] = lot
         new_flop["bidder"] = keeper_id
@@ -256,20 +305,22 @@ def make_flop_dent(flop_id, lot, keeper_id):
 
 
 def make_flop_deal(flop_id):
+    """ Needs to be refactored to `_all()` convention.
+    """
 
-    def flop_deal(_params, substep, sH, s, **kwargs):
+    def flop_deal(_params, _substep, _state_hist, state):
 
-        flop = s["flopper"][flop_id]
+        flop = state["flopper"][flop_id]
 
         expiry = flop["expiry"]
-        assert (expiry == 0)
+        assert expiry == 0
 
         # Move DAI bid from Keeper to Vow surplus
-        new_keepers = deepcopy(s["keepers"])
+        new_keepers = deepcopy(state["keepers"])
         new_keeper = new_keepers[flop["bidder"]]
         bid_dai = flop["bid_dai"]
         new_keeper["dai"] -= bid_dai
-        new_vow = deepcopy(s["vow"])
+        new_vow = deepcopy(state["vow"])
         new_vow["surplus_dai"] += bid_dai
 
         # Mint MKR lot
@@ -277,12 +328,12 @@ def make_flop_deal(flop_id):
         new_keeper["mkr"] += lot_mkr
 
         # Delete Flopper auction
-        new_flopper = deepcopy(s["flopper"])
+        new_flopper = deepcopy(state["flopper"])
         del new_flopper[flop_id]
 
         return {"vow": new_vow, "keepers": new_keepers, "flopper": new_flopper}
 
-    return flap_deal
+    return flop_deal
 
 
 # ---
@@ -290,5 +341,11 @@ def make_flop_deal(flop_id):
 
 # Utility
 
-def policy_reduce(policy_value_a, policy_value_b):
-    return {**policy_value_a, **policy_value_b}
+
+def policy_reduce(policy_signal_dict_a, policy_signal_dict_b):
+    """ Reduces policy signals by merging them into one dict.
+
+        If there is an overlap in keys, the value of `policy_signal_dict_b` is taken.
+    """
+
+    return {**policy_signal_dict_a, **policy_signal_dict_b}

--- a/dai_cadcad/sim_configs.py
+++ b/dai_cadcad/sim_configs.py
@@ -1,46 +1,59 @@
+""" Simulation Configurations Module
+
+Contains cadCAD configuration objects for different simulations, along with a dummy object to
+inherit from/reference.
+"""
+
 from cadCAD.configuration.utils import config_sim
 
 dummy_sim_config = {
     "T": range(1),
     "N": 1,
     "M": {
-        "SUMP": [0],        # Fixed DAI bid for Flopper auctions
-        "DUMP": [0],        # Initial MKR lot for Flopper auctions
-        "BUMP": [0],        # Fixed DAI lot for Flapper auctions
-        "HUMP": [0],        # Surplus DAI threshold that enables Flapper auctions
-        "FLIP_BEG": [0],    # Minimum DAI bid increase
-        "FLIP_TAU": [0],    # Auction duration
-        "FLOP_BEG": [0],    # Minimum ETH lot decrease
-        "FLOP_TAU": [0],    # Auction duration
-        "FLAP_BEG": [0],    # Minimum MKR bid increase
-        "FLAP_TAU": [0],    # Auction duration
-        "ETH_LINE": [0],    # ETH debt ceiling
-        "ETH_DUST": [0],    # ETH debt floor
-        "DSR": [0],         # Dai savings rate
-        "WARM_TAU": [0],    # Vault-joining warmup duration
-    }
+        "SUMP": [0],  # Fixed DAI bid for Flopper auctions
+        "DUMP": [0],  # Initial MKR lot for Flopper auctions
+        "BUMP": [0],  # Fixed DAI lot for Flapper auctions
+        "HUMP": [0],  # Surplus DAI threshold that enables Flapper auctions
+        "FLIP_BEG": [0],  # Minimum DAI bid increase
+        "FLIP_TAU": [0],  # Auction duration
+        "FLOP_BEG": [0],  # Minimum ETH lot decrease
+        "FLOP_TAU": [0],  # Auction duration
+        "FLAP_BEG": [0],  # Minimum MKR bid increase
+        "FLAP_TAU": [0],  # Auction duration
+        "ETH_LINE": [0],  # ETH debt ceiling
+        "ETH_DUST": [0],  # ETH debt floor
+        "DSR": [0],  # Dai savings rate
+        "WARM_TAU": [0],  # Vault-joining warmup duration
+    },
 }
 
 # Note: at least one of the array fields w/in the "M" key should be of length > 1
-# Otherwise, the `_params` dict gets passed in as a 1-element array to state update and policy functions
+
+# Otherwise, the `_params` dict gets passed in as a 1-element array to state update and policy
+# functions
+
 # This is likely a cadCAD bug
 
-join_bite_sim_config = config_sim({
-  **dummy_sim_config,
-  **{ "M": {
-        "SUMP": [0],
-        "DUMP": [0],
-        "BUMP": [0],
-        "HUMP": [0],
-        "FLIP_BEG": [0],
-        "FLIP_TAU": [0],
-        "FLOP_BEG": [0],
-        "FLOP_TAU": [0],
-        "FLAP_BEG": [0],
-        "FLAP_TAU": [0],
-        "ETH_LINE": [0, 160000],
-        "ETH_DUST": [0],
-        "DSR": [0],
-        "WARM_TAU": [0, 1],
-  }}
-})
+join_bite_sim_config = config_sim(
+    {
+        **dummy_sim_config,
+        **{
+            "M": {
+                "SUMP": [0],
+                "DUMP": [0],
+                "BUMP": [0],
+                "HUMP": [0],
+                "FLIP_BEG": [0],
+                "FLIP_TAU": [0],
+                "FLOP_BEG": [0],
+                "FLOP_TAU": [0],
+                "FLAP_BEG": [0],
+                "FLAP_TAU": [0],
+                "ETH_LINE": [0, 160000],
+                "ETH_DUST": [0],
+                "DSR": [0],
+                "WARM_TAU": [0, 1],
+            }
+        },
+    }
+)

--- a/dai_cadcad/state.py
+++ b/dai_cadcad/state.py
@@ -1,95 +1,117 @@
+""" State Module
+
+Contains the definition of the cadCAD system's state variables, along with dummy data as an
+expected schema.
+Additionally, it contains primitive state update functions (all the real logic is handled by the
+policies).
+"""
+
 initial_state = {
-  "vat": {
-    "dummy_vault": {
-      "vault_id": "",         # Vault ID
-      "eth": 0,               # Vault collateralization (ETH)
-      "dai": 0,               # Vault debt (DAI)
-      "bitten": False         # Whether or not the vault has been bitten
-    }
-  },
-  "vow": {
-    "debt_dai": 0,            # System debt (DAI)
-    "surplus_dai": 0,         # System surplus (DAI)
-  },
-  "flipper": {                # Tend -> dent
-    "dummy_flip": {
-      "flip_id": "",          # Auction ID
-      "phase": "",            # Auction phase ("tend" or "dent")
-      "debt_to_flip": 0,      # Desired amount of DAI to be raised from auction
-      "vault": "",            # Vault to send remaining ETH to after dent
-      "lot_eth": 0,           # Current lot (ETH)
-      "bid_dai": 0,           # Current bid (DAI)
-      "bidder": "",           # Current highest bidder
-      "expiry": 0,            # Auction expiration timestep
-    }
-  },
-  "flapper": {                # Tend
-    "dummy_flap": {
-      "flap_id": "",          # Auction ID
-      "lot_dai": 0,           # Current lot (DAI)
-      "bid_mkr": 0,           # Current bid (MKR)
-      "bidder": "",           # Current highest bidder
-      "expiry": 0,            # Auction expiration timestep
-    }
-  },
-  "flopper": {                # Dent
-    "dummy_flop": {
-      "flop_id": "",          # Auction ID
-      "lot_mkr": 0,           # Current lot (MKR)
-      "bid_dai": 0,           # Current bid (DAI)
-      "bidder": "",           # Current highest bidder
-      "expiry": 0,            # Auction expiration timestep
-    }
-  },
-  "keepers": {
-    "dummy_keeper": {
-      "keeper_id": "",        # Keeper ID
-      "dai": 0,               # DAI balance
-      "eth": 0,               # ETH balance
-      "mkr": 0,               # MKR balance
-      "flip_tolerance": 0,    # (TODO)
-      "flop_tolerance": 0,    # (TODO)
-      "flap_tolerance": 0     # (TODO)
-    }
-  },
-  "eth_ilk": {
-    "debt_dai": 0,            # Total amount of DAI collateralized by ETH
-    "spot_rate": 2/3,         # Conversion rate (max amount of DAI per ETH)
-    "stability_rate": 1       # Stability fee rate
-  },
+    "vat": {
+        "dummy_vault": {
+            "vault_id": "",  # Vault ID
+            "eth": 0,  # Vault collateralization (ETH)
+            "dai": 0,  # Vault debt (DAI)
+            "bitten": False,  # Whether or not the vault has been bitten
+        }
+    },
+    "vow": {
+        "debt_dai": 0,  # System debt (DAI)
+        "surplus_dai": 0,  # System surplus (DAI)
+    },
+    "flipper": {  # Tend -> dent
+        "dummy_flip": {
+            "flip_id": "",  # Auction ID
+            "phase": "",  # Auction phase ("tend" or "dent")
+            "debt_to_flip": 0,  # Desired amount of DAI to be raised from auction
+            "vault": "",  # Vault to send remaining ETH to after dent
+            "lot_eth": 0,  # Current lot (ETH)
+            "bid_dai": 0,  # Current bid (DAI)
+            "bidder": "",  # Current highest bidder
+            "expiry": 0,  # Auction expiration timestep
+        }
+    },
+    "flapper": {  # Tend
+        "dummy_flap": {
+            "flap_id": "",  # Auction ID
+            "lot_dai": 0,  # Current lot (DAI)
+            "bid_mkr": 0,  # Current bid (MKR)
+            "bidder": "",  # Current highest bidder
+            "expiry": 0,  # Auction expiration timestep
+        }
+    },
+    "flopper": {  # Dent
+        "dummy_flop": {
+            "flop_id": "",  # Auction ID
+            "lot_mkr": 0,  # Current lot (MKR)
+            "bid_dai": 0,  # Current bid (DAI)
+            "bidder": "",  # Current highest bidder
+            "expiry": 0,  # Auction expiration timestep
+        }
+    },
+    "keepers": {
+        "dummy_keeper": {
+            "keeper_id": "",  # Keeper ID
+            "dai": 0,  # DAI balance
+            "eth": 0,  # ETH balance
+            "mkr": 0,  # MKR balance
+            "flip_tolerance": 0,  # (TODO)
+            "flop_tolerance": 0,  # (TODO)
+            "flap_tolerance": 0,  # (TODO)
+        }
+    },
+    "eth_ilk": {
+        "debt_dai": 0,  # Total amount of DAI collateralized by ETH
+        "spot_rate": 2 / 3,  # Conversion rate (max amount of DAI per ETH)
+        "stability_rate": 1,  # Stability fee rate
+    },
 }
 
 
-def update_vat(_params, substep, sH, s, _input, **kwargs):
-    new_vat = _input['vat']
+def update_vat(_params, _substep, _state_hist, _state, policy_signals):
+    """ Updates `vat` state variable.
+    """
+    new_vat = policy_signals["vat"]
     return ("vat", new_vat)
 
 
-def update_vow(_params, substep, sH, s, _input, **kwargs):
-    new_vow = _input["vow"]
+def update_vow(_params, _substep, _state_hist, _state, policy_signals):
+    """ Updates `vow` state variable.
+    """
+    new_vow = policy_signals["vow"]
     return ("vow", new_vow)
 
 
-def update_flipper(_params, substep, sH, s, _input, **kwargs):
-    new_flipper = _input["flipper"]
+def update_flipper(_params, _substep, _state_hist, _state, policy_signals):
+    """ Updates `flipper` state variable.
+    """
+    new_flipper = policy_signals["flipper"]
     return ("flipper", new_flipper)
 
 
-def update_flopper(_params, substep, sH, s, _input, **kwargs):
-    new_flopper = _input["flopper"]
+def update_flopper(_params, _substep, _state_hist, _state, policy_signals):
+    """ Updates `flopper` state variable.
+    """
+    new_flopper = policy_signals["flopper"]
     return ("flopper", new_flopper)
 
 
-def update_flapper(_params, substep, sH, s, _input, **kwargs):
-    new_flapper = _input["flapper"]
+def update_flapper(_params, _substep, _state_hist, _state, policy_signals):
+    """ Updates `flapper` state variable.
+    """
+    new_flapper = policy_signals["flapper"]
     return ("flapper", new_flapper)
 
 
-def update_keepers(_params, substep, sH, s, _input, **kwargs):
-    new_keepers = _input["keepers"]
+def update_keepers(_params, _substep, _state_hist, _state, policy_signals):
+    """ Updates `keepers` state variable.
+    """
+    new_keepers = policy_signals["keepers"]
     return ("keepers", new_keepers)
 
 
-def update_eth_ilk(_params, substep, sH, s, _input, **kwargs):
-    new_eth_ilk = _input["eth_ilk"]
+def update_eth_ilk(_params, _substep, _state_hist, _state, policy_signals):
+    """ Updates `eth_ilk` state variable.
+    """
+    new_eth_ilk = policy_signals["eth_ilk"]
     return ("eth_ilk", new_eth_ilk)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,11 +1,32 @@
 [[package]]
 category = "dev"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+name = "appdirs"
+optional = false
+python-versions = "*"
+version = "1.4.4"
+
+[[package]]
+category = "dev"
 description = "Disable App Nap on OS X 10.9"
 marker = "sys_platform == \"darwin\" or platform_system == \"Darwin\" or python_version >= \"3.3\" and sys_platform == \"darwin\""
 name = "appnope"
 optional = false
 python-versions = "*"
 version = "0.1.0"
+
+[[package]]
+category = "dev"
+description = "An abstract syntax tree for Python with inference support."
+name = "astroid"
+optional = false
+python-versions = ">=3.5"
+version = "2.4.2"
+
+[package.dependencies]
+lazy-object-proxy = ">=1.4.0,<1.5.0"
+six = ">=1.12,<2.0"
+wrapt = ">=1.11,<2.0"
 
 [[package]]
 category = "dev"
@@ -32,11 +53,68 @@ tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.i
 
 [[package]]
 category = "dev"
+description = "Library for managing git hooks"
+name = "autohooks"
+optional = false
+python-versions = ">=3.5,<4.0"
+version = "2.1.0"
+
+[package.dependencies]
+colorful = ">=0.5.4,<0.6.0"
+packaging = ">=20.3,<21.0"
+tomlkit = ">=0.5.11,<0.6.0"
+
+[[package]]
+category = "dev"
+description = "Autohooks plugin for code formatting via black"
+name = "autohooks-plugin-black"
+optional = false
+python-versions = ">=3.5"
+version = "1.2.0"
+
+[package.dependencies]
+autohooks = ">=1.1"
+black = "*"
+
+[[package]]
+category = "dev"
+description = "Autohooks plugin for code linting via pylint"
+name = "autohooks-plugin-pylint"
+optional = false
+python-versions = ">=3.5"
+version = "1.2.0"
+
+[package.dependencies]
+autohooks = ">=1.1"
+pylint = "*"
+
+[[package]]
+category = "dev"
 description = "Specifications for callback functions passed in to an API"
 name = "backcall"
 optional = false
 python-versions = "*"
 version = "0.2.0"
+
+[[package]]
+category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
+optional = false
+python-versions = ">=3.6"
+version = "19.10b0"
+
+[package.dependencies]
+appdirs = "*"
+attrs = ">=18.1.0"
+click = ">=6.5"
+pathspec = ">=0.6,<1"
+regex = "*"
+toml = ">=0.9.4"
+typed-ast = ">=1.4.0"
+
+[package.extras]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 category = "dev"
@@ -67,12 +145,31 @@ pathos = "*"
 
 [[package]]
 category = "dev"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
+
+[[package]]
+category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "python_version >= \"3.3\" and sys_platform == \"win32\" or sys_platform == \"win32\""
+marker = "python_version >= \"3.3\" and sys_platform == \"win32\" or sys_platform == \"win32\" or platform_system == \"Windows\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.4.3"
+
+[[package]]
+category = "dev"
+description = "Terminal string styling done right, in Python."
+name = "colorful"
+optional = false
+python-versions = "*"
+version = "0.5.4"
+
+[package.dependencies]
+colorama = "*"
 
 [[package]]
 category = "main"
@@ -217,6 +314,20 @@ test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 
 [[package]]
 category = "dev"
+description = "A Python utility / library to sort Python imports."
+name = "isort"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "4.3.21"
+
+[package.extras]
+pipfile = ["pipreqs", "requirementslib"]
+pyproject = ["toml"]
+requirements = ["pipreqs", "pip-api"]
+xdg_home = ["appdirs (>=1.4.0)"]
+
+[[package]]
+category = "dev"
 description = "An autocompletion tool for Python that can be used for text editors."
 name = "jedi"
 optional = false
@@ -336,6 +447,14 @@ version = "1.2.0"
 
 [[package]]
 category = "dev"
+description = "A fast and thorough lazy object proxy."
+name = "lazy-object-proxy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.3"
+
+[[package]]
+category = "dev"
 description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
 optional = false
@@ -357,6 +476,14 @@ numpy = ">=1.15"
 pillow = ">=6.2.0"
 pyparsing = ">=2.0.3,<2.0.4 || >2.0.4,<2.1.2 || >2.1.2,<2.1.6 || >2.1.6"
 python-dateutil = ">=2.1"
+
+[[package]]
+category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
 
 [[package]]
 category = "dev"
@@ -527,6 +654,14 @@ ppft = ">=1.6.6.2"
 
 [[package]]
 category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.0"
+
+[[package]]
+category = "dev"
 description = "Pexpect allows easy control of interactive console applications."
 marker = "python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\""
 name = "pexpect"
@@ -632,6 +767,21 @@ name = "pygments"
 optional = false
 python-versions = ">=3.5"
 version = "2.6.1"
+
+[[package]]
+category = "dev"
+description = "python code static checker"
+name = "pylint"
+optional = false
+python-versions = ">=3.5.*"
+version = "2.5.3"
+
+[package.dependencies]
+astroid = ">=2.4.0,<=2.5"
+colorama = "*"
+isort = ">=4.2.5,<5"
+mccabe = ">=0.6,<0.7"
+toml = ">=0.7.1"
 
 [[package]]
 category = "main"
@@ -751,6 +901,14 @@ version = "1.9.0"
 
 [[package]]
 category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
+optional = false
+python-versions = "*"
+version = "2020.7.14"
+
+[[package]]
+category = "dev"
 description = "Send file to trash natively under Mac OS X, Windows and Linux."
 name = "send2trash"
 optional = false
@@ -791,6 +949,22 @@ test = ["pathlib2"]
 
 [[package]]
 category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.1"
+
+[[package]]
+category = "dev"
+description = "Style preserving TOML library"
+name = "tomlkit"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.5.11"
+
+[[package]]
+category = "dev"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 name = "tornado"
 optional = false
@@ -812,6 +986,14 @@ six = "*"
 
 [package.extras]
 test = ["pytest", "mock"]
+
+[[package]]
+category = "dev"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+name = "typed-ast"
+optional = false
+python-versions = "*"
+version = "1.4.1"
 
 [[package]]
 category = "main"
@@ -848,14 +1030,30 @@ version = "3.5.1"
 [package.dependencies]
 notebook = ">=4.4.1"
 
+[[package]]
+category = "dev"
+description = "Module for decorators, wrappers and monkey patching."
+name = "wrapt"
+optional = false
+python-versions = "*"
+version = "1.12.1"
+
 [metadata]
-content-hash = "1cbac2444f5ae06b4a9aa5ee728ae466e6d00f5ad7ed8be14c71c7af80f2df6f"
+content-hash = "9b00e62dde6902a43560ddcb547260f841fe914f79afacae1dcf3261a977d4bf"
 python-versions = "^3.8"
 
 [metadata.files]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
 appnope = [
     {file = "appnope-0.1.0-py2.py3-none-any.whl", hash = "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0"},
     {file = "appnope-0.1.0.tar.gz", hash = "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"},
+]
+astroid = [
+    {file = "astroid-2.4.2-py3-none-any.whl", hash = "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"},
+    {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -865,9 +1063,25 @@ attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
+autohooks = [
+    {file = "autohooks-2.1.0-py3-none-any.whl", hash = "sha256:b21863e4e47c612462cb8d5d6150072eb41ce8fc3eee687d56d1965b2f46c42b"},
+    {file = "autohooks-2.1.0.tar.gz", hash = "sha256:a9770c39ab80128ec9fbaf0584e6528837b2ea6ea5f2a156452d589cb3ba8b35"},
+]
+autohooks-plugin-black = [
+    {file = "autohooks-plugin-black-1.2.0.tar.gz", hash = "sha256:e69a18209f3fd584da903e87faf0e3685caa4d51a9e870ddb3c2b1aef93387b8"},
+    {file = "autohooks_plugin_black-1.2.0-py3-none-any.whl", hash = "sha256:5099f620e01d3fcfd70195e63f101d003528b40475e921829a9ebde000f2c5ee"},
+]
+autohooks-plugin-pylint = [
+    {file = "autohooks-plugin-pylint-1.2.0.tar.gz", hash = "sha256:b1acc77b7845622d969ea2bfe5d8a95ae16a80c2282ca43888f522c9be479d10"},
+    {file = "autohooks_plugin_pylint-1.2.0-py3-none-any.whl", hash = "sha256:f08cef7ce4374661a2087e621e8fda411f3b2c19ebb7c92c7ac47b57892f7a3d"},
+]
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+black = [
+    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
+    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
 ]
 bleach = [
     {file = "bleach-3.1.5-py2.py3-none-any.whl", hash = "sha256:2bce3d8fab545a6528c8fa5d9f9ae8ebc85a56da365c7f85180bfe96a35ef22f"},
@@ -877,9 +1091,17 @@ cadcad = [
     {file = "cadCAD-0.4.17-py3-none-any.whl", hash = "sha256:29729c13b9966f590c64f07d95f0d7680cfc77b2718bbc4429f1b56692a4f996"},
     {file = "cadCAD-0.4.17.tar.gz", hash = "sha256:fa1ae8e3645e7ed43dee61cef9c468f61ff9c99d8cde146c4ef9e050d572b336"},
 ]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+colorful = [
+    {file = "colorful-0.5.4-py2.py3-none-any.whl", hash = "sha256:8d264b52a39aae4c0ba3e2a46afbaec81b0559a99be0d2cfe2aba4cf94531348"},
+    {file = "colorful-0.5.4.tar.gz", hash = "sha256:86848ad4e2eda60cd2519d8698945d22f6f6551e23e95f3f14dfbb60997807ea"},
 ]
 cycler = [
     {file = "cycler-0.10.0-py2.py3-none-any.whl", hash = "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d"},
@@ -921,6 +1143,10 @@ ipython-genutils = [
 ipywidgets = [
     {file = "ipywidgets-7.5.1-py2.py3-none-any.whl", hash = "sha256:13ffeca438e0c0f91ae583dc22f50379b9d6b28390ac7be8b757140e9a771516"},
     {file = "ipywidgets-7.5.1.tar.gz", hash = "sha256:e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97"},
+]
+isort = [
+    {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
+    {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
 jedi = [
     {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
@@ -971,6 +1197,29 @@ kiwisolver = [
     {file = "kiwisolver-1.2.0-cp38-none-win32.whl", hash = "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf"},
     {file = "kiwisolver-1.2.0-cp38-none-win_amd64.whl", hash = "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd"},
     {file = "kiwisolver-1.2.0.tar.gz", hash = "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f"},
+]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-win32.whl", hash = "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-win_amd64.whl", hash = "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-win32.whl", hash = "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-win_amd64.whl", hash = "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
@@ -1029,6 +1278,10 @@ matplotlib = [
     {file = "matplotlib-3.3.0-cp39-cp39-win32.whl", hash = "sha256:244a9088140a4c540e0a2db9c8ada5ad12520efded592a46e5bc43ff8f0fd0aa"},
     {file = "matplotlib-3.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:f74c39621b03cec7bc08498f140192ac26ca940ef20beac6dfad3714d2298b2a"},
     {file = "matplotlib-3.3.0.tar.gz", hash = "sha256:24e8db94948019d531ce0bcd637ac24b1c8f6744ac86d2aa0eb6dbaeb1386f82"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mistune = [
     {file = "mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"},
@@ -1115,6 +1368,10 @@ parso = [
 pathos = [
     {file = "pathos-0.2.6.zip", hash = "sha256:51b48e54870e4f83a262e49b6369116ab2ecc5a217569a84c7ab726e27b1bc10"},
 ]
+pathspec = [
+    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
+    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
     {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
@@ -1180,6 +1437,10 @@ py = [
 pygments = [
     {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
     {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
+]
+pylint = [
+    {file = "pylint-2.5.3-py3-none-any.whl", hash = "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"},
+    {file = "pylint-2.5.3.tar.gz", hash = "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1264,6 +1525,29 @@ qtpy = [
     {file = "QtPy-1.9.0-py2.py3-none-any.whl", hash = "sha256:fa0b8363b363e89b2a6f49eddc162a04c0699ae95e109a6be3bb145a913190ea"},
     {file = "QtPy-1.9.0.tar.gz", hash = "sha256:2db72c44b55d0fe1407be8fba35c838ad0d6d3bb81f23007886dc1fc0f459c8d"},
 ]
+regex = [
+    {file = "regex-2020.7.14-cp27-cp27m-win32.whl", hash = "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"},
+    {file = "regex-2020.7.14-cp27-cp27m-win_amd64.whl", hash = "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88"},
+    {file = "regex-2020.7.14-cp36-cp36m-win32.whl", hash = "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4"},
+    {file = "regex-2020.7.14-cp36-cp36m-win_amd64.whl", hash = "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89"},
+    {file = "regex-2020.7.14-cp37-cp37m-win32.whl", hash = "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6"},
+    {file = "regex-2020.7.14-cp37-cp37m-win_amd64.whl", hash = "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a"},
+    {file = "regex-2020.7.14-cp38-cp38-win32.whl", hash = "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341"},
+    {file = "regex-2020.7.14-cp38-cp38-win_amd64.whl", hash = "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840"},
+    {file = "regex-2020.7.14.tar.gz", hash = "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb"},
+]
 send2trash = [
     {file = "Send2Trash-1.5.0-py3-none-any.whl", hash = "sha256:f1691922577b6fa12821234aeb57599d887c4900b9ca537948d2dac34aea888b"},
     {file = "Send2Trash-1.5.0.tar.gz", hash = "sha256:60001cc07d707fe247c94f74ca6ac0d3255aabcb930529690897ca2a39db28b2"},
@@ -1280,6 +1564,14 @@ testpath = [
     {file = "testpath-0.4.4-py2.py3-none-any.whl", hash = "sha256:bfcf9411ef4bf3db7579063e0546938b1edda3d69f4e1fb8756991f5951f85d4"},
     {file = "testpath-0.4.4.tar.gz", hash = "sha256:60e0a3261c149755f4399a1fff7d37523179a70fdc3abdf78de9fc2604aeec7e"},
 ]
+toml = [
+    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
+    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+]
+tomlkit = [
+    {file = "tomlkit-0.5.11-py2.py3-none-any.whl", hash = "sha256:4e1bd6c9197d984528f9ff0cc9db667c317d8881288db50db20eeeb0f6b0380b"},
+    {file = "tomlkit-0.5.11.tar.gz", hash = "sha256:f044eda25647882e5ef22b43a1688fb6ab12af2fc50e8456cdfc751c873101cf"},
+]
 tornado = [
     {file = "tornado-6.0.4-cp35-cp35m-win32.whl", hash = "sha256:5217e601700f24e966ddab689f90b7ea4bd91ff3357c3600fa1045e26d68e55d"},
     {file = "tornado-6.0.4-cp35-cp35m-win_amd64.whl", hash = "sha256:c98232a3ac391f5faea6821b53db8db461157baa788f5d6222a193e9456e1740"},
@@ -1295,6 +1587,29 @@ traitlets = [
     {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},
     {file = "traitlets-4.3.3.tar.gz", hash = "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"},
 ]
+typed-ast = [
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
+    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
 uuid = [
     {file = "uuid-1.30.tar.gz", hash = "sha256:1f87cc004ac5120466f36c5beae48b4c48cc411968eed0eaecd3da82aa96193f"},
 ]
@@ -1309,4 +1624,7 @@ webencodings = [
 widgetsnbextension = [
     {file = "widgetsnbextension-3.5.1-py2.py3-none-any.whl", hash = "sha256:bd314f8ceb488571a5ffea6cc5b9fc6cba0adaf88a9d2386b93a489751938bcd"},
     {file = "widgetsnbextension-3.5.1.tar.gz", hash = "sha256:079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7"},
+]
+wrapt = [
+    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ autohooks-plugin-black = "^1.2.0"
 
 [tool.autohooks]
 mode = "poetry"
+pre-commit = ["autohooks.plugins.pylint", "autohooks.plugins.black"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ autohooks-plugin-black = "^1.2.0"
 
 [tool.autohooks]
 mode = "poetry"
-pre-commit = ["autohooks.plugins.pylint", "autohooks.plugins.black"]
+pre-commit = ["autohooks.plugins.black", "autohooks.plugins.pylint"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,14 @@ uuid = "^1.30"
 pytest = "^5.2"
 ipykernel = "^5.3.3"
 jupyter = "^1.0.0"
+pylint = "^2.5.3"
+black = "^19.10b0"
+autohooks = "^2.1.0"
+autohooks-plugin-pylint = "^1.2.0"
+autohooks-plugin-black = "^1.2.0"
+
+[tool.autohooks]
+mode = "poetry"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Closes #31.

Final stack:
- `autohooks` to generate the pre-commit hooks
- `pylint`/`autohooks-plugin-pylint` for linting
- `black`/`autohooks-plugin-black` for formatting

Notes:
- After you pull this locally, you will have to run `poetry run autohooks activate` to set up the hooks in your local git repo.
- We will still want to configure the linting rules as we go, since they are currently very stringent. `autohooks` blocks commits from executing if there are linting errors.